### PR TITLE
Upgrade dependencies and Qulice (with linter fixes)

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+[default.extend-words]
+nd = "nd"

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.72.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>com.yegor256</groupId>
   <artifactId>mktmp</artifactId>
@@ -63,7 +63,7 @@
     </site>
   </distributionManagement>
   <properties>
-    <junit.version>6.0.1</junit.version>
+    <junit.version>6.0.3</junit.version>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.6</version>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/com/yegor256/MktmpResolver.java
+++ b/src/main/java/com/yegor256/MktmpResolver.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * This class is instantiated and then called by JUnit when
  * an argument of a test method is marked with the {@link Mktmp}
  * annotation.
- *
  * @since 0.1.0
  */
 public final class MktmpResolver implements ParameterResolver {
@@ -35,25 +35,18 @@ public final class MktmpResolver implements ParameterResolver {
     public Object resolveParameter(final ParameterContext context,
         final ExtensionContext ext) {
         final Path target = Paths.get("target").toAbsolutePath();
-        Path path = target
-            .resolve("mktmp")
-            .resolve(
-                ext.getTestClass()
-                    .map(Class::getSimpleName)
-                    .orElse(ext.getDisplayName())
-            )
-            .resolve(
-                context.getParameter()
-                    .getDeclaringExecutable()
-                    .getName()
-            );
+        Path path = target.resolve("mktmp").resolve(
+            ext.getTestClass().map(Class::getSimpleName).orElse(ext.getDisplayName())
+        ).resolve(
+            context.getParameter().getDeclaringExecutable().getName()
+        );
         while (true) {
             final Path sub = path.resolve(
                 String.format(
                     "%s-%s",
                     MktmpResolver.ordinal(context.getIndex() + 1),
                     DateTimeFormatter.ofPattern("mm'm'ss's'SSS", Locale.ROOT)
-                        .format(LocalDateTime.now())
+                        .format(LocalDateTime.now(ZoneId.systemDefault()))
                 )
             );
             if (sub.toFile().mkdirs()) {
@@ -88,5 +81,4 @@ public final class MktmpResolver implements ParameterResolver {
         }
         return String.format("%d%s", num, tail);
     }
-
 }

--- a/src/main/java/com/yegor256/package-info.java
+++ b/src/main/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Use it in your JUnit5 tests.
- *
  * @since 0.0.1
  */
 package com.yegor256;

--- a/src/test/java/com/yegor256/MktmpResolverTest.java
+++ b/src/test/java/com/yegor256/MktmpResolverTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link MktmpResolver}.
- *
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/package-info.java
+++ b/src/test/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests.
- *
  * @since 0.0.1
  */
 package com.yegor256;


### PR DESCRIPTION
@yegor256 this PR upgrades all stable Maven dependencies and the Qulice plugin in `mktmp`, fixes the new linter violations and the pre-existing `typos` failure, and adjusts the CI matrix accordingly.

### What changed

* `com.jcabi:parent` 0.72.0 → 0.73.1
* `org.junit.jupiter` (api/engine/params) 6.0.1 → 6.0.3 (via `<junit.version>` property)
* `com.qulice:qulice-maven-plugin` 0.25.1 → 0.27.6

### Linter fixes (Qulice 0.27.6 ships stricter rules)

* `MktmpResolver.java`
  * Removed empty Javadoc line before `@since` (`JavadocEmptyLineBeforeTagCheck`)
  * Flattened the multi-line `target.resolve(...)` chain so that fluent calls opening a multi-line block sit on the same line as the previous expression (`RegexpSinglelineCheck`)
  * Passed an explicit `ZoneId.systemDefault()` to `LocalDateTime.now()` to satisfy ErrorProne's `JavaTimeDefaultTimeZone`
  * Dropped the empty line before the class closing brace (`RegexpMultilineCheck`)
* `package-info.java` (main and test) and `MktmpResolverTest.java`: same `JavadocEmptyLineBeforeTagCheck` cleanup

### CI matrix

Qulice 0.27.x is compiled with class file version 65 (Java 21), so a Java 17 runner cannot load it (`UnsupportedClassVersionError` on `com/qulice/maven/CheckMojo`). Dropped Java 17 from the `mvn` matrix, leaving Java 21 only — this matches what other yegor256 repos already on Qulice 0.27.x do (`jaxec`, `jhome`, `tojos`, `together`).

### Pre-existing fixes pulled in along the way

* The `typos` workflow has been failing on `master` because of `tail = "nd"` in the ordinal helper (`"nd"` → `"and"`). Added a small `_typos.toml` whitelisting `nd` so the check goes green without changing source.

### Verification

* `mvn -B clean install -Pqulice` passes locally on Java 21.
* All 12 CI checks pass: `actionlint`, `copyrights`, `markdown-lint`, `mvn (macos-15, 21)`, `mvn (ubuntu-24.04, 21)`, `mvn (windows-2022, 21)`, `ort`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`.

### Note on overlap with open Renovate PRs

This PR partially overlaps with #19 (junit 6.0.3) and #31 (parent 0.73.1) — those have been waiting on the unrelated `typos` failure. Merging this PR makes both redundant and unblocks them either way.
