### PR TITLE
#43: fix ordinal suffix for teens (11th/12th/13th)

### DIFF
--- a/src/main/java/com/yegor256/MktmpResolver.java
+++ b/src/main/java/com/yegor256/MktmpResolver.java
@@ -63,6 +63,32 @@ public final class MktmpResolver implements ParameterResolver,
     }
 
     /**
+     * Turn index into an ordinal number.
+     *
+     * <p>The teens 11, 12 and 13 (and every {@code ...11}, {@code ...12},
+     * {@code ...13}) are an exception in English and always take "th", not
+     * "st"/"nd"/"rd".</p>
+     *
+     * @param num The number
+     * @return Ordinal one (1st, 2nd, 3rd, 8th, 11th, etc.)
+     */
+    static String ordinal(final int num) {
+        final String tail;
+        if (num % 100 / 10 == 1) {
+            tail = "th";
+        } else if (num % 10 == 1) {
+            tail = "st";
+        } else if (num % 10 == 2) {
+            tail = "nd";
+        } else if (num % 10 == 3) {
+            tail = "rd";
+        } else {
+            tail = "th";
+        }
+        return String.format("%d%s", num, tail);
+    }
+
+    /**
      * Inject a field.
      * @param test The test instance
      * @param field The field
@@ -156,24 +182,5 @@ public final class MktmpResolver implements ParameterResolver,
      */
     private static boolean supported(final Class<?> type) {
         return type.equals(Path.class) || type.equals(File.class);
-    }
-
-    /**
-     * Turn index into an ordinal number.
-     * @param num The number
-     * @return Ordinal one (1st, 2nd, 3rd, 8th, etc.)
-     */
-    private static String ordinal(final int num) {
-        final String tail;
-        if (num % 10 == 1) {
-            tail = "st";
-        } else if (num % 10 == 2) {
-            tail = "nd";
-        } else if (num % 10 == 3) {
-            tail = "rd";
-        } else {
-            tail = "th";
-        }
-        return String.format("%d%s", num, tail);
     }
 }

--- a/src/test/java/com/yegor256/MktmpResolverTest.java
+++ b/src/test/java/com/yegor256/MktmpResolverTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -22,6 +23,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @since 0.1.0
  */
 @ExtendWith(MktmpResolver.class)
+@SuppressWarnings("PMD.TooManyMethods")
 final class MktmpResolverTest {
 
     /**
@@ -51,6 +53,21 @@ final class MktmpResolverTest {
                 Matchers.containsString("onceTemp"),
                 Matchers.containsString("1st-")
             )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1, 1st", "2, 2nd", "3, 3rd", "4, 4th",
+        "11, 11th", "12, 12th", "13, 13th",
+        "21, 21st", "22, 22nd", "23, 23rd",
+        "111, 111th", "112, 112th", "113, 113th"
+    })
+    void formatsOrdinalSuffix(final int num, final String expected) {
+        MatcherAssert.assertThat(
+            "ordinal suffix must follow English rules, teens always take 'th'",
+            MktmpResolver.ordinal(num),
+            Matchers.equalTo(expected)
         );
     }
 


### PR DESCRIPTION
Closes #43.

## Problem

`MktmpResolver.ordinal(int)` derived the English ordinal suffix from `num % 10` alone, so the teens 11, 12, 13 (and every `...11`, `...12`, `...13`) got `st`/`nd`/`rd` instead of `th`. A `@Mktmp` parameter at index 10 produced a directory named `11st-...`, index 11 produced `12nd-...`, etc. — including the `111st`/`112nd`/`113rd` cases above 100.

## Fix

The teens are the standard English exception: whenever the tens digit is `1` (i.e. `10..19`, `110..119`, …) the suffix is always `th`. Check `num % 100 / 10 == 1` first and fall through to the existing units switch otherwise. The change is local to `ordinal`.

## Test

`ordinal` is made package-private so the suffix rule can be unit-tested directly — driving it through the resolver would require 11+ `@Mktmp` parameters, which the method-parameter limit forbids. Added a parameterized `formatsOrdinalSuffix` test covering units (1st/2nd/3rd/4th), the teens (11th/12th/13th), the twenties (21st/22nd/23rd) and the above-100 cases (111th/112th/113th).

Verified locally with `mvn test` (23 pass) and `mvn test-compile qulice:check -Pqulice` (green).